### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
   lazylibrarian:
     image: linuxserver/lazylibrarian:latest
     container_name: lazylibrarian
-    hostname: headphones
+    hostname: lazylibrarian
     ports:
       - "5299:5299"
     volumes:


### PR DESCRIPTION
Typo on line 118, looks like you copies the headphones template and changed it to work for lazylibrarian and forgot to change the hostname.