### PR TITLE
Fix casing of VERSION and combine plex env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,7 @@ services:
       - PGID
       - PUID
       - TZ
+      - VERSION=latest
     labels:
       traefik.enable: "true"
       traefik.port: "32400"
@@ -216,8 +217,6 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
     ports:
       - 32400:32400
-    environment:
-      version: "latest"
     restart: unless-stopped
 
   plexpy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,8 +215,6 @@ services:
       traefik.port: "32400"
       traefik.frontend.rule: "Host:plex.${DOMAIN}"
       com.centurylinklabs.watchtower.enable: "true"
-    ports:
-      - 32400:32400
     restart: unless-stopped
 
   plexpy:


### PR DESCRIPTION
Ran into this issue - not sure if its due to windows, but the duplicate environment blocks for Plex caused the GPID and GUID variables to be ignored.

In addition it seems as if the VERSION environment variable is case-sensitive, I could not get a Plex update to occur without making it uppercase.