### PR TITLE
Fix Heimdall https issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,7 +249,7 @@ services:
     restart: unless-stopped
 
   heimdall:
-    image: linuxserver/heimdall:latest
+    image: duhio/heimdall-https:latest
     container_name: heimdall
     hostname: heimdall
     volumes:
@@ -258,6 +258,7 @@ services:
       - PGID
       - PUID
       - TZ
+      - FORCE_HTTPS=true
     labels:
       traefik.enable: "true"
       traefik.port: "80"


### PR DESCRIPTION
Use a custom Docker image based on the official Heimdall image. Rather than adding more config work we bake in the required FORCE_HTTPS env var.

Fixes #25