### PR TITLE
Add env vars to ddclient

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
     container_name: ddclient
     volumes:
       - ${CONFIG}/ddclient:/config
+    environment:
+      - PGID
+      - PUID
+      - TZ      
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     restart: unless-stopped


### PR DESCRIPTION
I was getting an error on my Synology 918+ which manifested as ddclient not being able to get an IP address, which in turn meant that traefik couldn't get any certificates.  Adding the env vars to ddclient fixes this