### PR TITLE
Updating nzbhydra2 image location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
     restart: unless-stopped
 
   nzbhydra:
-    image: linuxserver/hydra2:latest
+    image: linuxserver/nzbhydra2:latest
     container_name: nzbhydra
     hostname: nzbhydra
     ports:


### PR DESCRIPTION
The hydra2 docker image location has been deprecated in favor of nzbhydra2 and is stuck at 2.x version.